### PR TITLE
FR-62 [BE] 내가 요청자로 속한 채팅방 전체 조회 API 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
@@ -2,16 +2,20 @@ package com.forpets.be.domain.chat.chatroom.controller;
 
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
+import com.forpets.be.domain.chat.chatroom.dto.response.VolunteerChatRoomListResponseDto;
 import com.forpets.be.domain.chat.chatroom.service.ChatRoomService;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,11 +25,20 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
+    // 채팅방 생성
     @PostMapping
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(
         @RequestBody ChatRoomRequestDto requestDto, @AuthenticationPrincipal User user) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
             ApiResponse.ok("채팅방이 생성되었습니다.", "CREATED",
                 chatRoomService.createChatRoom(requestDto, user)));
+    }
+
+    // 내가 요청자로 속한 채팅방 전체 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<VolunteerChatRoomListResponseDto>>> getChatRooms(
+        @RequestParam Long requestorId) {
+        return ResponseEntity.ok(ApiResponse.ok("요청자로 속한 채팅방 리스트가 조회되었습니다.", "OK",
+            chatRoomService.getChatRooms(requestorId)));
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/VolunteerChatRoomListResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/VolunteerChatRoomListResponseDto.java
@@ -1,0 +1,33 @@
+package com.forpets.be.domain.chat.chatroom.dto.response;
+
+import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Builder
+public class VolunteerChatRoomListResponseDto {
+
+    private final Long id;
+    private final String imageUrl;
+    private final String volunteerNickname;
+    private final String departureArea;
+    private final String arrivalArea;
+    private final LocalDateTime createdAt;
+
+    public static VolunteerChatRoomListResponseDto from(ChatRoom chatRoom) {
+        log.info("VolunteerChatRoomListResponseDto- chatRoom : {}", chatRoom);
+
+        return VolunteerChatRoomListResponseDto.builder()
+            .id(chatRoom.getId())
+            .imageUrl(chatRoom.getVolunteer().getImageUrl())
+            .volunteerNickname(chatRoom.getVolunteer().getNickname())
+            .departureArea(chatRoom.getServiceVolunteer().getDepartureArea())
+            .arrivalArea(chatRoom.getServiceVolunteer().getArrivalArea())
+            .createdAt(chatRoom.getCreatedAt())
+            .build();
+    }
+}

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
@@ -2,16 +2,23 @@ package com.forpets.be.domain.chat.chatroom.repository;
 
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
 import com.forpets.be.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    
+
     // 이미 존재하는 채팅방인지 확인
     @Query("SELECT CASE WHEN COUNT(c) > 0 THEN TRUE ELSE FALSE END "
         + "FROM ChatRoom c "
         + "WHERE c.requestor = :requestor AND c.volunteer = :volunteer")
     boolean existsByRequestorAndVolunteer(@Param("requestor") User requestor,
         @Param("volunteer") User volunteer);
+
+    // 내가 요청자로 속한 채팅방 전체 조회
+    @Query("SELECT c FROM ChatRoom c "
+        + "JOIN FETCH c.requestor r "
+        + "WHERE r.id = :requestorId")
+    List<ChatRoom> findAllByRequestorId(@Param("requestorId") Long requestorId);
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -2,16 +2,20 @@ package com.forpets.be.domain.chat.chatroom.service;
 
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
+import com.forpets.be.domain.chat.chatroom.dto.response.VolunteerChatRoomListResponseDto;
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
 import com.forpets.be.domain.chat.chatroom.repository.ChatRoomRepository;
 import com.forpets.be.domain.servicevolunteer.entity.ServiceVolunteer;
 import com.forpets.be.domain.servicevolunteer.repository.VolunteerRepository;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.domain.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class ChatRoomService {
     private final VolunteerRepository volunteerRepository;
     private final UserRepository userRepository;
 
+    // 채팅방 생성
     @Transactional
     public ChatRoomResponseDto createChatRoom(ChatRoomRequestDto requestDto, User user) {
         User requestor = null;
@@ -60,6 +65,17 @@ public class ChatRoomService {
             .build();
 
         return ChatRoomResponseDto.from(chatRoomRepository.save(chatRoom));
+    }
+
+    // 내가 요청자로 속한 채팅방 전체 조회
+    public List<VolunteerChatRoomListResponseDto> getChatRooms(Long requestorId) {
+        List<ChatRoom> chatRoom = chatRoomRepository.findAllByRequestorId(requestorId);
+
+        if (chatRoom.isEmpty()) {
+            throw new IllegalArgumentException("요청자로 속한 채팅방이 존재하지 않습니다.");
+        }
+
+        return chatRoom.stream().map(VolunteerChatRoomListResponseDto::from).toList();
     }
 }
 


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-62

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 내가 요청자로 속한 채팅방이 리스트로 조회되도록 구현
  - 봉사 등록글에 대한 이미지, 봉사자 닉네임, 출발 가능 지역, 도착 가능 지역, 글 생성 시간을 응답

## 📸 스크린샷
<img width="1075" alt="스크린샷 2025-03-26 오후 2 59 49" src="https://github.com/user-attachments/assets/1c85e7a1-f904-4042-ab8b-eb12b49d8906" />

## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항