### PR TITLE
FR-51 [FE] 카카오 소셜 로그인 프론트 구현

### DIFF
--- a/fe/src/pages/Login.jsx
+++ b/fe/src/pages/Login.jsx
@@ -25,6 +25,10 @@ function Login() {
       alert('사용자 정보가 맞지 않습니다.');
     }
   };
+  const handleKakaoLogin = () => {
+    window.location.href = 'http://localhost:8080/oauth2/authorization/kakao';
+  };
+
   return (
     <>
       <form
@@ -52,7 +56,7 @@ function Login() {
         >
           로그인
         </button>
-        <button className="h-10 text-center  rounded-md cursor-pointer">
+        <button className="h-10 text-center  rounded-md cursor-pointer" onClick={handleKakaoLogin}>
           <img
             className="w-[100%] h-[100%] rounded-md overflow-hidden"
             src="/assets/kakao-login-button.png"

--- a/fe/src/pages/SocialLogin.jsx
+++ b/fe/src/pages/SocialLogin.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { login } from '../store/slices/authSlice';
+
+function SocialLogin() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation(); // 현재 URL 정보 가져오기
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search); // ✅ 쿼리 파라미터 읽기
+
+    const accessToken = params.get('accessToken');
+    const username = params.get('username');
+
+    if (accessToken && username) {
+      console.log('✅ 소셜 로그인 성공! Redux 저장 중...');
+
+      // Redux 저장 (authSlice.js에서 localStorage도 자동 저장됨)
+
+      dispatch(login({ accessToken, username }));
+
+      // ✅ 메인 페이지 이동
+      navigate('/');
+    } else {
+      console.error('❌ 소셜 로그인 실패: 토큰이 없음');
+      navigate('/login');
+    }
+  }, [dispatch, navigate, location]);
+  return <div>소셜 로그인 중...</div>;
+}
+
+export default SocialLogin;

--- a/fe/src/router/index.jsx
+++ b/fe/src/router/index.jsx
@@ -17,7 +17,7 @@ import VolunteerList from '../pages/VolunteerList';
 import VolunteerDetail from '../pages/VolunteerDetail';
 import ProfileEditCard from '../components/mypage/ProfileEditCard';
 import RescueAnimalList from '../pages/RescueAnimalList';
-
+import SocialLogin from '../pages/SocialLogin';
 // 로그아웃시 뒤로가기로 마이페이지, 나의채팅 페이지 이동 막는 컴포넌트
 import PrivateRoute from '../components/PrivateRoute';
 import RescueAnimalDetail from '../pages/RescueAnimalDetail';
@@ -42,6 +42,10 @@ const router = createBrowserRouter([
       {
         path: '/login',
         element: <Login />,
+      },
+      {
+        path: '/social-login',
+        element: <SocialLogin />,
       },
       {
         path: '/signup',


### PR DESCRIPTION

## 🔍 관련 Jira 이슈

- FR-51

## 📝 변경 사항

- 카카오 로그인 버튼을 누르면 일단 인가 코드 뜨고
- 그 인가 코드를 이용하여 백엔드에서 유저 정보 추출
- 추출한 정보를 유저테이블에 저장 및 username과 accessToken을  쿼리 파라미터로 프론트에 보냄 (값을 꺼내오기 위해 SocialLogin 컴포넌트 생성)
	- refreshToken은 쿠키로 보내서 그냥 넘어옴
- SocialLogin 컴포넌트에서 username과 accessToken을 받아서 redux slice의 login에 저장
- 만들어진 프로세스에 따라 login에 username과 accessToken이 저장되면서 로그인 처리됨.

## 📸 스크린샷


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
- 현재 일반 로그인때는 쿠키에 refresh-token이라 저장되지만
- 소셜 로그인 시에는 refreshToken이라고 저장됨 (수정 필요)
- 유저가 어떤 소셜 서비스로 로그인 했는지 파악하려고 userEntity에 provider 컬럼 넣었는데 snsProvider라고 명칭 바꿀지 논의 필요