### PR TITLE
FR-70 [BE] 소셜 로그인 코드 수정 및 yml 복구

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/user/entity/User.java
+++ b/be/src/main/java/com/forpets/be/domain/user/entity/User.java
@@ -54,16 +54,16 @@ public class User extends BaseTimeEntity implements UserDetails {
     // 화면 출력용
     @Column(nullable = true)
     private String originalFileName;
-    
+
     // Role을 통해 사용자의 권한을 정의
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private String provider; // 어떤 OAuth인지(google, kakao, naver)
+    private String snsProvider; // 어떤 OAuth인지(google, kakao, naver)
 
     @Builder
     public User(String username, String password, String nickname, String originalFileName,
-        Role role, String imageUrl, String s3Key, String provider) {
+        Role role, String imageUrl, String s3Key, String snsProvider) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
@@ -71,7 +71,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.originalFileName = originalFileName;
         this.imageUrl = imageUrl;
         this.s3Key = s3Key;
-        this.provider = provider;
+        this.snsProvider = snsProvider;
     }
 
     @Override

--- a/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
@@ -47,7 +47,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 //        아직 안 됨.
         String socialName = "";
         log.info("프로바이더: {}", provider);
-        
+
         if (provider == "google") {
             socialName = "sub";
         } else {
@@ -79,7 +79,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             .username(userInfo.getUsername())  // username을 소셜 로그인 ID로 설정
             .password(UUID.randomUUID().toString())
             .nickname(nickname)  // 실제 사용 X
-            .provider(provider)
+            .snsProvider(provider)
             .role(Role.ROLE_USER)
             .build();
         return userRepository.save(newUser);

--- a/be/src/main/java/com/forpets/be/global/auth/service/OAuth2AuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/OAuth2AuthenticationSuccessHandler.java
@@ -92,7 +92,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 //        accessTokenCookie.setMaxAge(10);
 
         // RefreshToken을 HttpOnly 쿠키로 설정
-        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        Cookie refreshTokenCookie = new Cookie("refresh-token",refreshToken);
+            // 일반 로그인 refreshToken 저장 시 refresh-token이라 변경
         refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방지
         refreshTokenCookie.setSecure(true);  // HTTPS에서만 전송 (개발 환경에서는 false로 변경 가능)
         refreshTokenCookie.setPath("/");  // 모든 경로에서 사용 가능

--- a/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
@@ -63,7 +63,7 @@ public class OAuth2UserInfo {
         return User.builder()
             .username(id)
             .password(password)
-            .provider(provider)
+            .snsProvider(provider)
             .nickname(nickname)
             .username(username)
             .build();

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
           auth: 'true'
     password: ${SMTP_PASSWORD}
 
+  mvc:
+    throw-exception-if-no-handler-found: 'true'
+  web:
+    resources:
+      add-mappings: 'false'
+
   security:
     oauth2:
       client:


### PR DESCRIPTION

## 🔍 관련 Jira 이슈

- FR-70

## 📝 변경 사항
- 일반 로그인 시 refresh-token으로 쿠키에 저장되서 키 명칭 refresh-token으로 변경
- 경식님이 작성했던 yml 코드 복구
- 원호님이 제안하신 UserEntity의 provider 명칭 snsProvider로 변경

## 📸 스크린샷


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
