### PR TITLE
FR-65 [BE] 채팅방 생성 API 추가 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/request/ChatRoomRequestDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/request/ChatRoomRequestDto.java
@@ -1,5 +1,6 @@
 package com.forpets.be.domain.chat.chatroom.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoomRequestDto {
+
+    @NotNull
+    private Long myAnimalId;
 
     private Long serviceVolunteerId;
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomResponseDto.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class ChatRoomResponseDto {
 
     private final Long id;
+    private final Long myAnimalId;
     private final Long serviceVolunteerId;
     private final String requestorNickname;
     private final String volunteerNickname;
@@ -20,7 +21,9 @@ public class ChatRoomResponseDto {
     public static ChatRoomResponseDto from(ChatRoom entity) {
         return ChatRoomResponseDto.builder()
             .id(entity.getId())
-            .serviceVolunteerId(entity.getServiceVolunteer().getId())
+            .myAnimalId(entity.getMyAnimal().getId())
+            .serviceVolunteerId(
+                entity.getServiceVolunteer() != null ? entity.getServiceVolunteer().getId() : null)
             .requestorNickname(entity.getRequestor().getNickname())
             .volunteerNickname(entity.getVolunteer().getNickname())
             .state(entity.getState())

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.forpets.be.domain.chat.chatroom.entity;
 
+import com.forpets.be.domain.animal.entity.MyAnimal;
 import com.forpets.be.domain.servicevolunteer.entity.ServiceVolunteer;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.entity.BaseTimeEntity;
@@ -27,7 +28,9 @@ public class ChatRoom extends BaseTimeEntity {
     @Column(name = "chat_room_id")
     private Long id;
 
-    // Todo: 나의 아이 필드도 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "my_animal_id", nullable = false)
+    private MyAnimal myAnimal;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "service_volunteer_id")
@@ -46,7 +49,9 @@ public class ChatRoom extends BaseTimeEntity {
     private RoomState state;
 
     @Builder
-    public ChatRoom(ServiceVolunteer serviceVolunteer, User requestor, User volunteer) {
+    public ChatRoom(MyAnimal myAnimal, ServiceVolunteer serviceVolunteer, User requestor,
+        User volunteer) {
+        this.myAnimal = myAnimal;
         this.serviceVolunteer = serviceVolunteer;
         this.requestor = requestor;
         this.volunteer = volunteer;

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package com.forpets.be.domain.chat.chatroom.service;
 
+import com.forpets.be.domain.animal.entity.MyAnimal;
+import com.forpets.be.domain.animal.repository.MyAnimalRepository;
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.VolunteerChatRoomListResponseDto;
@@ -22,23 +24,45 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final MyAnimalRepository myAnimalRepository;
     private final VolunteerRepository volunteerRepository;
     private final UserRepository userRepository;
 
     // 채팅방 생성
     @Transactional
     public ChatRoomResponseDto createChatRoom(ChatRoomRequestDto requestDto, User user) {
+        ServiceVolunteer serviceVolunteer = null;
         User requestor = null;
         User volunteer = null;
 
-        ServiceVolunteer serviceVolunteer = volunteerRepository.findById(
-                requestDto.getServiceVolunteerId())
-            .orElseThrow(() -> new IllegalArgumentException("해당 봉사 등록글이 존재하지 않습니다."));
+        MyAnimal myAnimal = myAnimalRepository.findById(requestDto.getMyAnimalId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 나의 아이 등록글이 존재하지 않습니다."));
 
-        // Todo: 나의 아이 등록글에서 채팅이 시작된 경우 로직 구현 필요
+        // 나의 아이 등록글에서 채팅이 시작된 경우
+        if (requestDto.getServiceVolunteerId() == null) {
+            log.info("ChatRoomService- myAnimal: {}", myAnimal.getUser());
+
+            // 요청자는 나의 아이 등록글의 user_id를 통해 정보를 가져옴
+            requestor = userRepository.findById(myAnimal.getUser().getId())
+                .orElseThrow(() -> new IllegalArgumentException("요청자 정보를 찾을 수 없습니다."));
+
+            // 봉사자는 로그인한 사용자
+            volunteer = user;
+
+            // 요청자와 봉사자가 동일한지 확인하고 예외 처리 (필요할 경우)
+            if (volunteer.getId().equals(requestor.getId())) {
+                throw new IllegalArgumentException("요청자와 봉사자는 동일할 수 없습니다.");
+            }
+        }
 
         // 봉사글에서 채팅이 시작된 경우
         if (requestDto.getServiceVolunteerId() != null) {
+            serviceVolunteer = volunteerRepository.findById(
+                    requestDto.getServiceVolunteerId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 봉사 등록글이 존재하지 않습니다."));
+
+            log.info("ChatRoomService- serviceVolunteer: {}", serviceVolunteer.getUser());
+
             // 요청자는 로그인한 사용자
             requestor = user;
 
@@ -46,7 +70,7 @@ public class ChatRoomService {
             volunteer = userRepository.findById(serviceVolunteer.getUser().getId())
                 .orElseThrow(() -> new IllegalArgumentException("봉사자 정보를 찾을 수 없습니다."));
 
-            // 요청자와 봉사자가 동일한지 확인하고 예외 처리 (필요할 경우)
+            // 요청자와 봉사자가 동일한지 확인하고 예외 처리
             if (requestor.getId().equals(volunteer.getId())) {
                 throw new IllegalArgumentException("요청자와 봉사자는 동일할 수 없습니다.");
             }
@@ -59,6 +83,7 @@ public class ChatRoomService {
         }
 
         ChatRoom chatRoom = ChatRoom.builder()
+            .myAnimal(myAnimal)
             .serviceVolunteer(serviceVolunteer)
             .requestor(requestor)
             .volunteer(volunteer)


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-65

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 나의 아이 등록글을 통한 채팅방 생성 로직 추가
- 응답 데이터에 나의 아이 등록글 id, 봉사 등록글 id, 요청자 닉네임, 봉사자 닉네임을 포함해서 응답

## 📸 스크린샷
- 나의 아이 게시글을 통해 채팅을 생성한 경우
<img width="1078" alt="스크린샷 2025-03-26 오후 8 30 15" src="https://github.com/user-attachments/assets/76658833-a005-4a6c-a902-9d3abbaf0ce3" />

- 봉사 등록글을 통해 채팅을 생성한 경우
<img width="1076" alt="스크린샷 2025-03-26 오후 8 53 49" src="https://github.com/user-attachments/assets/21ee62c6-31cf-4434-ad4b-04f46b8af16f" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항