### PR TITLE
FR-83 [BE] 채팅방 상세 조회 API 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/dto/response/ChatMessageResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/dto/response/ChatMessageResponseDto.java
@@ -1,0 +1,24 @@
+package com.forpets.be.domain.chat.chatmessage.dto.response;
+
+import com.forpets.be.domain.chat.chatmessage.entity.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageResponseDto {
+
+    private Long id;
+    private Long chatRoomId;
+    private Long senderId;
+    private String content;
+
+    public static ChatMessageResponseDto from(ChatMessage chatMessage) {
+        return ChatMessageResponseDto.builder()
+            .id(chatMessage.getId())
+            .chatRoomId(chatMessage.getChatRoom().getId())
+            .senderId(chatMessage.getSenderId())
+            .content(chatMessage.getContent())
+            .build();
+    }
+}

--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/repository/ChatMessageRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/repository/ChatMessageRepository.java
@@ -1,8 +1,12 @@
 package com.forpets.be.domain.chat.chatmessage.repository;
 
 import com.forpets.be.domain.chat.chatmessage.entity.ChatMessage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
+    // 해당 채팅방의 채팅 메시지 내역 조회
+    List<ChatMessage> findByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatroom.controller;
 
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
+import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomDetailResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.RequestorChatRoomsListResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.VolunteerChatRoomsListResponseDto;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,5 +50,13 @@ public class ChatRoomController {
         @RequestParam Long volunteerId) {
         return ResponseEntity.ok(ApiResponse.ok("봉사자로 속한 채팅방 리스트가 조회되었습니다.", "OK",
             chatRoomService.getVolunteerChatRooms(volunteerId)));
+    }
+
+    // 채팅방 개별 조회
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<ChatRoomDetailResponseDto>> getChatRoom(
+        @PathVariable Long chatRoomId) {
+        return ResponseEntity.ok(ApiResponse.ok(chatRoomId + "번 채팅방이 조회되었습니다.", "OK",
+            chatRoomService.getChatRoomById(chatRoomId)));
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
@@ -1,0 +1,37 @@
+package com.forpets.be.domain.chat.chatroom.dto.response;
+
+import com.forpets.be.domain.animal.dto.response.MyAnimalReadResponseDto;
+import com.forpets.be.domain.chat.chatmessage.dto.response.ChatMessageResponseDto;
+import com.forpets.be.domain.chat.chatroom.entity.RoomState;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatRoomDetailResponseDto {
+
+    private Long id;
+    private String nickName;
+    private String departureArea;
+    private String arrivalArea;
+
+    private MyAnimalReadResponseDto myAnimal;
+    private RoomState state;
+    private List<ChatMessageResponseDto> chatMessages;
+
+    public static ChatRoomDetailResponseDto from(Long chatRoomId, String nickname,
+        String departureArea,
+        String arrivalArea, MyAnimalReadResponseDto responseDto, RoomState state,
+        List<ChatMessageResponseDto> chatMessages) {
+        return ChatRoomDetailResponseDto.builder()
+            .id(chatRoomId)
+            .nickName(nickname)
+            .departureArea(departureArea)
+            .arrivalArea(arrivalArea)
+            .myAnimal(responseDto)
+            .state(state)
+            .chatMessages(chatMessages)
+            .build();
+    }
+}

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
@@ -3,6 +3,7 @@ package com.forpets.be.domain.chat.chatroom.repository;
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
 import com.forpets.be.domain.user.entity.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -34,4 +35,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         + "WHERE c.id = :chatRoomId AND (c.requestor.id = :userId OR c.volunteer.id = :userId)")
     boolean existsUserByRequestorAndVolunteer(@Param("chatRoomId") Long chatRoomId,
         @Param("userId") Long userId);
+
+    // 채팅방에서 필요한 연관 데이터들을 한 번에 조회
+    @Query("SELECT cr FROM ChatRoom cr "
+        + "JOIN FETCH cr.myAnimal ma "
+        + "LEFT JOIN FETCH cr.serviceVolunteer sv "
+        + "WHERE cr.id = :chatRoomId")
+    Optional<ChatRoom> findChatRoomWithDetails(@Param("chatRoomId") Long chatRoomId);
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -1,8 +1,12 @@
 package com.forpets.be.domain.chat.chatroom.service;
 
+import com.forpets.be.domain.animal.dto.response.MyAnimalReadResponseDto;
 import com.forpets.be.domain.animal.entity.MyAnimal;
 import com.forpets.be.domain.animal.repository.MyAnimalRepository;
+import com.forpets.be.domain.chat.chatmessage.dto.response.ChatMessageResponseDto;
+import com.forpets.be.domain.chat.chatmessage.repository.ChatMessageRepository;
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
+import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomDetailResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.RequestorChatRoomsListResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.RequestorChatRoomsResponseDto;
@@ -30,6 +34,7 @@ public class ChatRoomService {
     private final MyAnimalRepository myAnimalRepository;
     private final VolunteerRepository volunteerRepository;
     private final UserRepository userRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     // 채팅방 생성
     @Transactional
@@ -114,5 +119,42 @@ public class ChatRoomService {
 
         return VolunteerChatRoomsListResponseDto.from(chatRooms, total);
     }
-}
 
+    // 채팅방 개별 조회
+    public ChatRoomDetailResponseDto getChatRoomById(Long chatRoomId) {
+        // 채팅방 정보 로드
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomWithDetails(chatRoomId)
+            .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        // 닉네임 결정
+        // 봉사 등록글이 null => 나의 아이 등록글을 통해 시작된 채팅인 경우 => 요청자 : 나의 아이 등록글 작성자(상대방), 봉사자 : 로그인한 사용자(나) 처리
+        // 봉사 등록글이 not null => 봉사 등록글을 통해 시작된 채팅인 경우 => 요청자 : 로그인한 사용자(나), 봉사자 : 봉사 등록글 작성자(상대방) 처리
+        String nickname = (chatRoom.getServiceVolunteer() == null)
+            ? chatRoom.getRequestor().getNickname()
+            : chatRoom.getVolunteer().getNickname();
+
+        // 출발지/도착지 결정
+        // 봉사 등록글이 null => 나의 아이 등록글을 통해 시작된 채팅인 경우 => 출발 요청 지역, 도착 요청 지역 처리
+        // 봉사 등록글이 not null => 봉사 등록글을 통해 시작된 채팅인 경우 => 출발 가능 지역, 도착 가능 지역 처리
+        String departureArea = (chatRoom.getServiceVolunteer() == null)
+            ? chatRoom.getMyAnimal().getDepartureArea()
+            : chatRoom.getServiceVolunteer().getDepartureArea();
+
+        String arrivalArea = (chatRoom.getServiceVolunteer() == null)
+            ? chatRoom.getMyAnimal().getArrivalArea()
+            : chatRoom.getServiceVolunteer().getArrivalArea();
+
+        // 나의 아이 등록글의 정보 조회
+        MyAnimalReadResponseDto responseDto = MyAnimalReadResponseDto.from(chatRoom.getMyAnimal());
+
+        // 해당 채팅방의 채팅 메시지 내역 조회
+        List<ChatMessageResponseDto> chatMessages = chatMessageRepository.findByChatRoomId(
+                chatRoomId).stream()
+            .map(ChatMessageResponseDto::from)
+            .toList();
+
+        return ChatRoomDetailResponseDto.from(chatRoomId, nickname, departureArea, arrivalArea,
+            responseDto,
+            chatRoom.getState(), chatMessages);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-83

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 봉사자 또는 요청자 닉네임, 출발 가능 지역 또는 출발 요청 지역, 도착 가능 지역 또는 도착 요청 지역, 나의 아이 정보, 방 상태(시작 전/진행 중/완료), 채팅 메시지 내역 조회
  - 내가 요청자로 참여하는지 봉사자로 참여하는지에 따라 닉네임, 출발지, 도착지 내용이 달라지게 설정
- 필드로 데이터를 응답하지 않는 데이터에 대해서는 DTO 형태로 생성해서 응답 (ChatMessageResponseDto)

## 📸 스크린샷
<img width="1210" alt="스크린샷 2025-03-28 오후 12 16 22" src="https://github.com/user-attachments/assets/ecc92330-4116-4641-a1e0-f849d8c1a890" />

<img width="1213" alt="스크린샷 2025-03-28 오후 12 16 30" src="https://github.com/user-attachments/assets/37658d10-9725-439a-90e7-ce6443ade451" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항