### PR TITLE
FR-85 [BE] 네이버 소셜 로그인 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
@@ -55,6 +55,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             socialName = "id";
         } else if (provider.equals("naver")) {
             socialName = "response";
+            // 기본 이메일 (연락처 이메일)
         }
         log.info(socialName);
 

--- a/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/CustomOAuth2UserService.java
@@ -32,36 +32,56 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 소셜 로그인 서비스 제공자 이름(google, kakao, naver)
         String provider = oAuth2UserRequest.getClientRegistration().getRegistrationId();
 
-        // 어떤 소셜 서비스인지에 따라 정보를 다르게 매핑
+        log.info("유저 서비스에서의 프로바이더 : {}", provider);
+
+        // 어떤 소셜 서비스인지에 따라 정보를 다르게 매핑해서 저장
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(provider, oAuth2User.getAttributes());
 
-        log.info("소셜 로그인 제공자: {}", provider);
-        log.info("소셜 로그인 ID: {}", oAuth2UserInfo.getId());
-        log.info("소셜 로그인 이메일: {}", oAuth2UserInfo.getUsername());
+        log.info("OAuth2UserInfo Attributes: {}", oAuth2User.getAttributes());
+        log.info("OAuth2UserInfo Email: {}", oAuth2UserInfo.getUsername());
+        log.info("OAuth2UserInfo Provider: {}", oAuth2UserInfo.getProvider());
 
         System.out.println(oAuth2UserInfo.getProvider());
         // 가입한 유저인지 확인(
         User user = userRepository.findByUsername(oAuth2UserInfo.getUsername())
             .orElseGet(() -> saveUser(oAuth2UserInfo, provider));
+        log.info("유저 이메일 : {}", user.getUsername());
 
-//        아직 안 됨.
         String socialName = "";
-        log.info("프로바이더: {}", provider);
 
-        if (provider == "google") {
+        if (provider.equals("google")) {
             socialName = "sub";
-        } else {
+        } else if (provider.equals("kakao")) {
             socialName = "id";
+        } else if (provider.equals("naver")) {
+            socialName = "response";
         }
+        log.info(socialName);
 
-        log.info("소셜 종류: {}", socialName);
         return new DefaultOAuth2User(
             Collections.emptySet(),
             oAuth2User.getAttributes(),
-            "id"
-//            socialName
+//            "id"
+            socialName
         );
-
+//        Map<String, Object> attributes = oAuth2User.getAttributes();
+//
+//        String socialName = "";
+//        if (provider.equals("google")) {
+//            socialName = "sub";
+//        } else if (provider.equals("naver")) {
+//            attributes = (Map<String, Object>) attributes.get("response");
+//            socialName = "id";
+//        } else if (provider.equals("kakao")) {
+//            socialName = "id";
+//        }
+//        log.info(socialName);
+//
+//        return new DefaultOAuth2User(
+//            Collections.emptySet(),
+//            attributes,
+//            socialName
+//        );
     }
 
     public String generateUniqueNickname(UserRepository userRepository) {

--- a/be/src/main/java/com/forpets/be/global/auth/service/OAuth2AuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/OAuth2AuthenticationSuccessHandler.java
@@ -3,7 +3,6 @@ package com.forpets.be.global.auth.service;
 
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.domain.user.repository.UserRepository;
-import com.forpets.be.global.auth.dto.response.OAuth2ResponseDto;
 import com.forpets.be.global.redis.RedisRepository;
 import com.forpets.be.global.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
@@ -38,34 +37,31 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         log.info("OAuth2User 정보 : {}", oAuth2User.getAttributes());
 
-        // OAuth2User에서 사용자 정보 가져오기
-        String email = (String) oAuth2User.getAttributes().get("email");
-//        log.info("로그인한 사용자 email:{}", email);
-
         // provider 구별용 변수명
         String provider = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
 
-        // 구글은 그냥 가져오지만 카카오는 따로 설정해줘야 함.
-        Object kakaoAccountObj = oAuth2User.getAttributes().get("kakao_account");
-
-//        if ("kakao".equals(provider)) {
-//            Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes()
-//                .get("kakao_account");
-//            email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
-
-        if (kakaoAccountObj instanceof Map) {
-            Map<String, Object> kakaoAccount = (Map<String, Object>) kakaoAccountObj;
-            email = (String) kakaoAccount.get("email");
-        } else {
+        String email = "";
+        // 구글은 그냥 가져오지만 카카오, 네이버는 따로 설정해줘야 함.
+        if ("google".equals(provider)) {
             email = (String) oAuth2User.getAttributes().get("email");
+            log.info("네이버 oAuth2 유저정보 : {}", oAuth2User.getAttributes());
+        } else if ("kakao".equals(provider)) {
+            Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes()
+                .get("kakao_account");
+            email = (String) kakaoAccount.get("email");
+            log.info("네이버 oAuth2 유저정보 : {}", oAuth2User.getAttributes());
+        } else if ("naver".equals(provider)) {
+            Map<String, Object> responseMap = (Map<String, Object>) oAuth2User.getAttributes()
+                .get("response");
+            email = (String) responseMap.get("email");
+//            email = (String) responseMap.get("email_address");    # 검수 후 사용
+            log.info("네이버 oAuth2 유저정보 : {}", oAuth2User.getAttributes());
         }
+
         log.info("로그인한 사용자 email:{}", email);
 
         User user = userRepository.findByUsername(email)
             .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
-
-//        UsernamePasswordAuthenticationToken authentication =
-//            new UsernamePasswordAuthenticationToken(user, null);
 
         // JWT 발급
         String accessToken = jwtTokenProvider.createAccessToken(user.getUsername());
@@ -77,59 +73,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         redisRepository.storeRefreshToken(user.getUsername(), refreshToken);
         log.info("RefreshToken 저장 완료");
 
-//        // username을 HttpOnly 쿠키로 설정
-//        Cookie usernameCookie = new Cookie("username", user.getUsername());
-//        usernameCookie.setHttpOnly(true);  // XSS 공격 방지
-//        usernameCookie.setSecure(true);  // HTTPS에서만 전송 (개발 환경에서는 false로 변경 가능)
-//        usernameCookie.setPath("/");  // 모든 경로에서 사용 가능
-//        usernameCookie.setMaxAge(10);
-//
-//        // accessToken을 HttpOnly 쿠키로 설정
-//        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-//        accessTokenCookie.setHttpOnly(true);  // XSS 공격 방지
-//        accessTokenCookie.setSecure(true);  // HTTPS에서만 전송 (개발 환경에서는 false로 변경 가능)
-//        accessTokenCookie.setPath("/");  // 모든 경로에서 사용 가능
-//        accessTokenCookie.setMaxAge(10);
-
         // RefreshToken을 HttpOnly 쿠키로 설정
         Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-        // 일반 로그인 refreshToken 저장 시 refresh-token이라 변경
         refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방지
         refreshTokenCookie.setSecure(true);  // HTTPS에서만 전송 (개발 환경에서는 false로 변경 가능)
         refreshTokenCookie.setPath("/");  // 모든 경로에서 사용 가능
         refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);  // 7일 동안 유지 (초 단위) (refreshToken의 길이만큼)
 
-//        response.addCookie(usernameCookie);
-//        log.info("유저네임 쿠키 : {}", usernameCookie);
-//        response.addCookie(accessTokenCookie);
         response.addCookie(refreshTokenCookie); // 응답에 쿠키 추가
         log.info("RefreshToken 쿠키 저장 완료");
-//
-        OAuth2ResponseDto responseDto = OAuth2ResponseDto.builder()
-            .id(user.getId())
-            .username(user.getUsername())
-            .accessToken(accessToken) // 리프레시 토큰은 쿠키로 전달해서 없음
-            .build();
-//
-        // JSON으로 응답
-//        response.setContentType("application/json");
-//        response.setCharacterEncoding("UTF-8");
-//        String targetUrl = "http://localhost:5173";
-//        getRedirectStrategy().sendRedirect(request, response, targetUrl);
-
-//        response.getWriter().write(new ObjectMapper().writeValueAsString(responseDto));
-        log.info("ResponseDto username : {}", responseDto.getUsername());
-        log.info("ResponseDto accessToken :{}", responseDto.getAccessToken());
-//
-
-//        log.info("ResponseDto 응답 : {}", );
-//        String redirectUrl = UriComponentsBuilder.fromUriString(URI).
-
-        // json으로 응답이 안 되서 redirectUrl 설정
-//        String redirectUrl = UriComponentsBuilder.fromUriString(URI)
-//            .queryParam("accessToken", accessToken)
-//            .build().toUriString();
-//        response.sendRedirect(redirectUrl);
 
         String targetUrl =
             "http://localhost:5173/social-login?accessToken=" + accessToken + "&username=" + email;

--- a/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
@@ -5,19 +5,22 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Builder
 @Getter
 @ToString
 public class OAuth2UserInfo {
 
-    private String id;
+    //    private String id;
     private String password;
     private String username;
     private String nickname;
     private String provider;
 
     public static OAuth2UserInfo of(String provider, Map<String, Object> attributes) {
+        log.info("유저인포에서의 프로바이더 : {}", provider);
         switch (provider) {
             case "google":
                 return ofGoogle(attributes);
@@ -33,7 +36,7 @@ public class OAuth2UserInfo {
     private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
         return OAuth2UserInfo.builder()
             .provider("google")
-            .id("google_" + (String) attributes.get("sub"))
+//            .id("google_" + (String) attributes.get("sub"))
             .password((String) attributes.get("sub"))
             .nickname((String) attributes.get("name"))
             .username((String) attributes.get("email"))
@@ -43,7 +46,7 @@ public class OAuth2UserInfo {
     private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
         return OAuth2UserInfo.builder()
             .provider("kakao")
-            .id("kakao_" + attributes.get("id").toString())
+//            .id("kakao_" + attributes.get("id").toString())
             .password(attributes.get("id").toString())
             .username((String) ((Map) attributes.get("kakao_account")).get("email")) // 이메일 정보 추출
 //            .nickname((String) ((Map) attributes.get("properties")).get("nickname"))
@@ -53,19 +56,23 @@ public class OAuth2UserInfo {
     private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
         return OAuth2UserInfo.builder()
             .provider("naver")
-            .id("naver_" + (String) ((Map) attributes.get("response")).get("id"))
-            .password((String) ((Map) attributes.get("response")).get("id"))
+//            .id("naver_" + (String) ((Map) attributes.get("response")).get("id"))
+            // 연락처 이메일 주소라 example@naver.com 이 아닐수도 있음
+            .username((String) ((Map) attributes.get("response")).get("email"))
+            // 검수 완료 후 사용(진짜 네이버 이메일 주소)
+//            .username((String) ((Map) attributes.get("response")).get("email_addressl"))
+//            .password((String) ((Map) attributes.get("response")).get("id"))
 //            .nickname((String) ((Map) attributes.get("response")).get("name"))
             .build();
     }
 
     public User toEntity() {
+        log.info("유저인포에서의 유저네임 : {}", username);
         return User.builder()
-            .username(id)
+            .username(username)
             .password(password)
             .snsProvider(provider)
             .nickname(nickname)
-            .username(username)
             .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
+++ b/be/src/main/java/com/forpets/be/global/auth/service/OAuth2UserInfo.java
@@ -54,11 +54,17 @@ public class OAuth2UserInfo {
     }
 
     private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        String email = response.containsKey("email_address") ?
+            (String) response.get("email_address") :
+            (String) response.get("email");
+        
         return OAuth2UserInfo.builder()
             .provider("naver")
 //            .id("naver_" + (String) ((Map) attributes.get("response")).get("id"))
+            .username(email)
             // 연락처 이메일 주소라 example@naver.com 이 아닐수도 있음
-            .username((String) ((Map) attributes.get("response")).get("email"))
+//            .username((String) ((Map) attributes.get("response")).get("email"))
             // 검수 완료 후 사용(진짜 네이버 이메일 주소)
 //            .username((String) ((Map) attributes.get("response")).get("email_addressl"))
 //            .password((String) ((Map) attributes.get("response")).get("id"))

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -56,10 +56,11 @@ spring:
             client-secret: ${naver-client-secret} # 발급 받은 Client Secret
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
             scope:
               #              - name
               - email
+            #              - email_address    # 검수 후 사용
             #              - profile_image
             client-name: Naver
 


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-85

## 📝 변경 사항

네이버 소셜 로그인 백엔드단 구현

## 📸 스크린샷


## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

- 네이버 소셜 로그인 시
- email_address(~~~@naver.com)이 있으면 쓰고
- 없으면 email(연락처 이메일) 사용
- email일 경우 ~~~@naver.com이 아닐 수도 있음

- 현재 제 카카오 이메일이 ~~~@gmail.com인데
- 네이버 연락처 이메일에 동일한 ~~~@gmail.com 등록해서
- 네이버 연동 해도 db에서 이미 있는 이메일이라
- 신규 유저로 추가가 안 되고 기존에 저장된 카카오로 로그인 되고 있습니다.

- 만일 네이버 연락처 이메일이랑 다른 소셜 로그인이랑 이메일 주소가 같다면 동일한 증상 발생 예정이라
- UserEntity나 소셜 로그인 시 처리를 어떻게 해야 할 것인가에 대한 논의 필요.