### PR TITLE
FR-89 [BE] 채팅, 나의 아이 응답 데이터 코드 수정

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/animal/dto/response/MyAnimalReadResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/animal/dto/response/MyAnimalReadResponseDto.java
@@ -19,6 +19,7 @@ public class MyAnimalReadResponseDto {
     private String departureArea;
     private String arrivalArea;
     private String breed;
+    private Integer age;
     private Integer weight;
     private String notice;
     private String memo;
@@ -33,6 +34,7 @@ public class MyAnimalReadResponseDto {
             .departureArea(myAnimal.getDepartureArea())
             .arrivalArea(myAnimal.getArrivalArea())
             .breed(myAnimal.getBreed())
+            .age(myAnimal.getAge())
             .weight(myAnimal.getWeight())
             .notice(myAnimal.getNotice())
             .memo(myAnimal.getMemo())

--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/dto/response/ChatMessageResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/dto/response/ChatMessageResponseDto.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatmessage.dto.response;
 
 import com.forpets.be.domain.chat.chatmessage.entity.ChatMessage;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class ChatMessageResponseDto {
     private Long chatRoomId;
     private Long senderId;
     private String content;
+    private LocalDateTime createdAt;
 
     public static ChatMessageResponseDto from(ChatMessage chatMessage) {
         return ChatMessageResponseDto.builder()
@@ -19,6 +21,7 @@ public class ChatMessageResponseDto {
             .chatRoomId(chatMessage.getChatRoom().getId())
             .senderId(chatMessage.getSenderId())
             .content(chatMessage.getContent())
+            .createdAt(chatMessage.getCreatedAt())
             .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/entity/ChatMessage.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/entity/ChatMessage.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatmessage.entity;
 
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
+import com.forpets.be.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ChatMessage {
+public class ChatMessage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/service/ChatMessageService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/service/ChatMessageService.java
@@ -47,7 +47,10 @@ public class ChatMessageService {
     @Transactional
     public ChatMessage sendMessage(Long chatRoomId, ChatMessageRequestDto requestDto) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 채팅방을 찾을 수 없습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
+
+        User user = userRepository.findById(requestDto.getSenderId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
         ChatMessage chatMessage = requestDto.toEntity(chatRoom);
 

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
@@ -8,6 +8,7 @@ import com.forpets.be.domain.chat.chatroom.dto.response.VolunteerChatRoomsListRe
 import com.forpets.be.domain.chat.chatroom.service.ChatRoomService;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,7 @@ public class ChatRoomController {
     // 채팅방 생성
     @PostMapping
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(
-        @RequestBody ChatRoomRequestDto requestDto, @AuthenticationPrincipal User user) {
+        @RequestBody @Valid ChatRoomRequestDto requestDto, @AuthenticationPrincipal User user) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
             ApiResponse.ok("채팅방이 생성되었습니다.", "CREATED",
                 chatRoomService.createChatRoom(requestDto, user)));

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
@@ -3,6 +3,7 @@ package com.forpets.be.domain.chat.chatroom.dto.response;
 import com.forpets.be.domain.animal.dto.response.MyAnimalReadResponseDto;
 import com.forpets.be.domain.chat.chatmessage.dto.response.ChatMessageResponseDto;
 import com.forpets.be.domain.chat.chatroom.entity.RoomState;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,26 +13,13 @@ import lombok.Getter;
 public class ChatRoomDetailResponseDto {
 
     private Long id;
-    private String nickName;
+    private String nickname;
     private String departureArea;
     private String arrivalArea;
 
     private MyAnimalReadResponseDto myAnimal;
     private RoomState state;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
     private List<ChatMessageResponseDto> chatMessages;
-
-    public static ChatRoomDetailResponseDto from(Long chatRoomId, String nickname,
-        String departureArea,
-        String arrivalArea, MyAnimalReadResponseDto responseDto, RoomState state,
-        List<ChatMessageResponseDto> chatMessages) {
-        return ChatRoomDetailResponseDto.builder()
-            .id(chatRoomId)
-            .nickName(nickname)
-            .departureArea(departureArea)
-            .arrivalArea(arrivalArea)
-            .myAnimal(responseDto)
-            .state(state)
-            .chatMessages(chatMessages)
-            .build();
-    }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomResponseDto.java
@@ -17,6 +17,7 @@ public class ChatRoomResponseDto {
     private final String volunteerNickname;
     private final RoomState state;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public static ChatRoomResponseDto from(ChatRoom entity) {
         return ChatRoomResponseDto.builder()
@@ -28,6 +29,7 @@ public class ChatRoomResponseDto {
             .volunteerNickname(entity.getVolunteer().getNickname())
             .state(entity.getState())
             .createdAt(entity.getCreatedAt())
+            .updatedAt(entity.getUpdatedAt())
             .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/RequestorChatRoomsResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/RequestorChatRoomsResponseDto.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatroom.dto.response;
 
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
+import com.forpets.be.domain.chat.chatroom.entity.RoomState;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,9 @@ public class RequestorChatRoomsResponseDto {
     private final String volunteerNickname;
     private final String departureArea;
     private final String arrivalArea;
+    private final RoomState state;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public static RequestorChatRoomsResponseDto from(ChatRoom chatRoom) {
         log.info("VolunteerChatRoomListResponseDto- chatRoom : {}", chatRoom);
@@ -28,7 +31,9 @@ public class RequestorChatRoomsResponseDto {
             .volunteerNickname(chatRoom.getVolunteer().getNickname())
             .departureArea(chatRoom.getServiceVolunteer().getDepartureArea())
             .arrivalArea(chatRoom.getServiceVolunteer().getArrivalArea())
+            .state(chatRoom.getState())
             .createdAt(chatRoom.getCreatedAt())
+            .updatedAt(chatRoom.getUpdatedAt())
             .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/VolunteerChatRoomsResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/VolunteerChatRoomsResponseDto.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatroom.dto.response;
 
 import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
+import com.forpets.be.domain.chat.chatroom.entity.RoomState;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,9 @@ public class VolunteerChatRoomsResponseDto {
     private final String requestorNickname;
     private final String departureArea;
     private final String arrivalArea;
+    private final RoomState state;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public static VolunteerChatRoomsResponseDto from(ChatRoom chatRoom) {
         return VolunteerChatRoomsResponseDto.builder()
@@ -24,7 +27,9 @@ public class VolunteerChatRoomsResponseDto {
             .requestorNickname(chatRoom.getRequestor().getNickname())
             .departureArea(chatRoom.getMyAnimal().getDepartureArea())
             .arrivalArea(chatRoom.getMyAnimal().getArrivalArea())
+            .state(chatRoom.getState())
             .createdAt(chatRoom.getCreatedAt())
+            .updatedAt(chatRoom.getUpdatedAt())
             .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
@@ -37,11 +37,11 @@ public class ChatRoom extends BaseTimeEntity {
     private ServiceVolunteer serviceVolunteer;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "requestor_user_id")
+    @JoinColumn(name = "requestor_user_id", nullable = false)
     private User requestor;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "volunteer_user_id")
+    @JoinColumn(name = "volunteer_user_id", nullable = false)
     private User volunteer;
 
     @Enumerated(EnumType.STRING)

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
@@ -10,12 +10,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    // 이미 존재하는 채팅방인지 확인
+    // 나의 아이 등록글과 봉사 등록글 id를 확인하고 특정 게시글에서 시작된 채팅방이 이미 존재하는지 조회
     @Query("SELECT CASE WHEN COUNT(c) > 0 THEN TRUE ELSE FALSE END "
         + "FROM ChatRoom c "
-        + "WHERE c.requestor = :requestor AND c.volunteer = :volunteer")
-    boolean existsRoomByRequestorAndVolunteer(@Param("requestor") User requestor,
-        @Param("volunteer") User volunteer);
+        + "WHERE c.requestor = :requestor AND c.volunteer = :volunteer "
+        + "AND (c.myAnimal.id = :myAnimalId OR c.serviceVolunteer.id = :serviceVolunteerId)")
+    boolean existsRoomByRequestorAndVolunteerAndPost(
+        @Param("requestor") User requestor,
+        @Param("volunteer") User volunteer,
+        @Param("myAnimalId") Long myAnimalId,
+        @Param("serviceVolunteerId") Long serviceVolunteerId);
 
     // 내가 요청자로 속한 채팅방 전체 조회
     @Query("SELECT c FROM ChatRoom c "

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -46,8 +46,9 @@ public class ChatRoomService {
         MyAnimal myAnimal = myAnimalRepository.findById(requestDto.getMyAnimalId())
             .orElseThrow(() -> new IllegalArgumentException("해당 나의 아이 등록글이 존재하지 않습니다."));
 
-        // 나의 아이 등록글에서 채팅이 시작된 경우
         if (requestDto.getServiceVolunteerId() == null) {
+            // 나의 아이 등록글에서 채팅이 시작된 경우
+
             log.info("ChatRoomService- myAnimal: {}", myAnimal.getUser());
 
             // 요청자는 나의 아이 등록글의 user_id를 통해 정보를 가져옴
@@ -57,14 +58,13 @@ public class ChatRoomService {
             // 봉사자는 로그인한 사용자
             volunteer = user;
 
-            // 요청자와 봉사자가 동일한지 확인하고 예외 처리 (필요할 경우)
+            // 요청자와 봉사자가 동일한지 확인하고 예외 처리
             if (volunteer.getId().equals(requestor.getId())) {
                 throw new IllegalArgumentException("요청자와 봉사자는 동일할 수 없습니다.");
             }
-        }
+        } else {
+            // 봉사글에서 채팅이 시작된 경우
 
-        // 봉사글에서 채팅이 시작된 경우
-        if (requestDto.getServiceVolunteerId() != null) {
             serviceVolunteer = volunteerRepository.findById(
                     requestDto.getServiceVolunteerId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 봉사 등록글이 존재하지 않습니다."));
@@ -84,10 +84,10 @@ public class ChatRoomService {
             }
         }
 
-        // 해당 나의 아이 게시글 또는 봉사 등록글에서 생성한 채팅방이 이미 존재하는 경우에 대한 예외 처리 필요
-        // 채팅방 중복 생성 방지
-        if (chatRoomRepository.existsRoomByRequestorAndVolunteer(requestor, volunteer)) {
-            throw new IllegalStateException("이미 존재하는 채팅방입니다.");
+        // 나의 아이 등록글과 봉사 등록글 id를 확인하여 특정 게시글에서 시작된 채팅방이 이미 존재하는지 확인
+        if (chatRoomRepository.existsRoomByRequestorAndVolunteerAndPost(requestor, volunteer,
+            requestDto.getMyAnimalId(), requestDto.getServiceVolunteerId())) {
+            throw new IllegalStateException("이미 해당 게시글로 생성된 채팅방이 존재합니다.");
         }
 
         ChatRoom chatRoom = ChatRoom.builder()

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -153,8 +153,16 @@ public class ChatRoomService {
             .map(ChatMessageResponseDto::from)
             .toList();
 
-        return ChatRoomDetailResponseDto.from(chatRoomId, nickname, departureArea, arrivalArea,
-            responseDto,
-            chatRoom.getState(), chatMessages);
+        return ChatRoomDetailResponseDto.builder()
+            .id(chatRoomId)
+            .nickname(nickname)
+            .departureArea(departureArea)
+            .arrivalArea(arrivalArea)
+            .myAnimal(responseDto)
+            .state(chatRoom.getState())
+            .createdAt(chatRoom.getCreatedAt())
+            .updatedAt(chatRoom.getUpdatedAt())
+            .chatMessages(chatMessages)
+            .build();
     }
 }

--- a/be/src/main/java/com/forpets/be/global/config/SecurityConfig.java
+++ b/be/src/main/java/com/forpets/be/global/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/logout").authenticated()
-                .requestMatchers("/api/auth/**", "/ws/**", "/error", "/auth/success",
+                .requestMatchers("/api/auth/**", "/ws/connection", "/error", "/auth/success",
                     "/api/animals").permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-89

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 내가 요청자로 참여한 채팅방 전체 조회 응답 데이터 수정
  - 방 상태 (state) 정보 추가
  - 채팅방 수정 시간(UpdatedAt) 추가

- 내가 봉사자로 참여한 채팅방 전체 조회 응답 데이터 수정
  - 방 상태 (state) 정보 추가
  - 채팅방 수정 시간(UpdatedAt) 추가

- 채팅방 생성 응답 데이터 수정
  - 채팅방 수정 시간(UpdatedAt) 추가

- 채팅 메시지 조회 응답 데이터, ChatMessage 엔티티 수정
  - 메시지 생성 시간(CreatedAt) 필드 추가
  - ChatMessage 엔티티가 BaseTimeEntity클래스 extends하도록 수정

- 채팅방 상세 조회 응답 데이터 수정
  - 채팅방 생성 시간(CreatedAt) 필드 추가
  - 채팅방 수정 시간(UpdatedAt) 필드 추가
  - nickName 필드명을 nickname으로 수정
    
- ChatRoom 엔티티, ChatRoomController 수정
  - requestor 필드에 nullable=false 속성 추가
  - volunteer 필드에 nullable=false 속성 추가
  - ChatRoomController클래스의 채팅방 생성에서 @Valid 검증 어노테이션 추가
    
- 봉사글에서 채팅이 시작된 경우 조건문 수정, 채팅방 중복 생성 방지 로직 수정
  - 채팅방 생성 메서드(createChatRoom)에서 ‘봉사글에서 채팅이 시작된 경우’를 else if로 처리하도록 수정
    - 채팅은 요청글이나 봉사글을 통해서만 생성될 수 있으므로 if문을 두 번 사용하는 것보다 요청글 조건에 걸리거나 아니면 봉사글 조건에 걸리도록 else if로 처리하는 것이 좋아보임
  - 기존에는 ‘동일한 요청자와 봉사자가 생성한 채팅방이 이미 존재하는지 확인’하는 로직 -> ‘나의 아이 등록글과 봉사 등록글 id를 확인하여 특정 게시글에서 시작된 채팅방 중에 동일한 요청자와 봉사자가 생성한 채팅방이 이미 존재하는지 확인’하는 로직으로 수정

- SecurityConfig /ws 경로 허용했던 거 수정
  - `/ws/**` 코드 삭제
    - 채팅은 로그인 된 상태에서 사용할 수 있는 거고 연결, 구독, 메시지 발신할 때 헤더에 Access Token 넣어주면 됨

- 채팅 메시지를 보낸 사람(sender)이 존재하는 회원인지(user 테이블에 존재하는지) 대조하는 로직 추가

- 나의 아이 상세 조회 (MyAnimalReadResponseDto) 응답 데이터 수정
  - 나이(age) 필드 추가

## 📸 스크린샷


## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항