### PR TITLE
FR-95 [BE] 채팅방 수정 API 구현

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -22,7 +22,7 @@ jobs:
           restore-keys: docker-cache-
 
       - name: Create .env file
-        run: echo """${{ secrets.ENV_FILE }}""" >> .env
+        run: echo "${{ secrets.ENV_FILE }}" | base64 -d > .env
 
       - name: echo .env
         run: cat .env
@@ -53,8 +53,8 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          source: 'docker-compose.yml,.env'
-          target: '~/github-actions-work-directory'
+          source: "docker-compose.yml,.env"
+          target: "~/github-actions-work-directory"
 
       - name: Pull Image & Up Container
         uses: appleboy/ssh-action@v1.0.3

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.chat.chatroom.controller;
 
 import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomRequestDto;
+import com.forpets.be.domain.chat.chatroom.dto.request.ChatRoomUpdateRequestRecord;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomDetailResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.ChatRoomResponseDto;
 import com.forpets.be.domain.chat.chatroom.dto.response.RequestorChatRoomsListResponseDto;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,5 +61,15 @@ public class ChatRoomController {
         @PathVariable Long chatRoomId) {
         return ResponseEntity.ok(ApiResponse.ok(chatRoomId + "번 채팅방이 조회되었습니다.", "OK",
             chatRoomService.getChatRoomById(chatRoomId)));
+    }
+
+    // 채팅방 수정
+    @PatchMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<ChatRoomResponseDto>> updateChatRoom(
+        @PathVariable Long chatRoomId,
+        @RequestBody @Valid ChatRoomUpdateRequestRecord requestRecord,
+        @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(ApiResponse.ok(chatRoomId + "번 채팅방이 수정되었습니다.", "OK",
+            chatRoomService.updateChatRoom(chatRoomId, requestRecord, user)));
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/request/ChatRoomUpdateRequestRecord.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/request/ChatRoomUpdateRequestRecord.java
@@ -1,0 +1,8 @@
+package com.forpets.be.domain.chat.chatroom.dto.request;
+
+import com.forpets.be.domain.chat.chatroom.entity.RoomState;
+import jakarta.validation.constraints.NotNull;
+
+public record ChatRoomUpdateRequestRecord(@NotNull(message = "상태는 필수 입력값입니다") RoomState state) {
+
+}

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
@@ -57,4 +57,11 @@ public class ChatRoom extends BaseTimeEntity {
         this.volunteer = volunteer;
         this.state = RoomState.getDefault();
     }
+
+    // 채팅방 상태 업데이트
+    public ChatRoom updateState(RoomState state) {
+        this.state = state;
+
+        return this;
+    }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-95

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 채팅방 방 상태 업데이트 로직 구현
  - 약속잡기 매칭 시 state를 IN_PROGRESS로, 약속 취소 시 state를 BEFORE_START로, 이동봉사 완료 시 state를 DONE으로 수정 가능하도록 로직 구현
  - 로그인한 사용자가 본인이 참여하고 있는 채팅방만 방 상태 수정 (약속 잡기, 약속 취소, 이동 완료)이 가능하도록 검증 로직 구현

- GitHub Actions 환경변수 관련 수정

## 📸 스크린샷
<img width="1018" alt="스크린샷 2025-03-29 오전 11 28 33" src="https://github.com/user-attachments/assets/33d3bf7d-d50f-472b-a502-dab63f26bac0" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항