### PR TITLE
FR-97 [FE] 나의 아이 더보기 리스트 화면 구현

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -22,11 +22,7 @@ jobs:
           restore-keys: docker-cache-
 
       - name: Create .env file
-<<<<<<< Updated upstream
-        run: echo "${{ secrets.ENV_FILE }}" | base64 -d > .env
-=======
         run: echo """${{ secrets.ENV_FILE }}""" > .env
->>>>>>> Stashed changes
 
       - name: echo .env
         run: cat .env

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -22,7 +22,11 @@ jobs:
           restore-keys: docker-cache-
 
       - name: Create .env file
+<<<<<<< Updated upstream
         run: echo "${{ secrets.ENV_FILE }}" | base64 -d > .env
+=======
+        run: echo """${{ secrets.ENV_FILE }}""" > .env
+>>>>>>> Stashed changes
 
       - name: echo .env
         run: cat .env

--- a/be/src/main/java/com/forpets/be/domain/animal/dto/request/MyAnimalCreateRequestDto.java
+++ b/be/src/main/java/com/forpets/be/domain/animal/dto/request/MyAnimalCreateRequestDto.java
@@ -40,7 +40,7 @@ public class MyAnimalCreateRequestDto {
     @Size(min = 2, max = 10, message = "품종은 2자 이상 10자 이하여야 합니다")
     private String breed;
 
-    @Positive
+    //    @Positive
     @Range(min = 0, max = 25)
     private Integer age;
 

--- a/be/src/main/java/com/forpets/be/domain/animal/repository/MyAnimalRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/animal/repository/MyAnimalRepository.java
@@ -3,8 +3,12 @@ package com.forpets.be.domain.animal.repository;
 import com.forpets.be.domain.animal.entity.MyAnimal;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MyAnimalRepository extends JpaRepository<MyAnimal, Long> {
 
     List<MyAnimal> findByUserId(Long userID);
+
+    @Query("SELECT a FROM MyAnimal a ORDER BY a.selectedDate DESC")
+    List<MyAnimal> findAllOrderByCreatedAtDesc();
 }

--- a/be/src/main/java/com/forpets/be/domain/animal/service/MyAnimalService.java
+++ b/be/src/main/java/com/forpets/be/domain/animal/service/MyAnimalService.java
@@ -25,7 +25,8 @@ public class MyAnimalService {
     }
 
     public AnimalsResponseDto getAnimals() {
-        List<MyAnimalReadResponseDto> animals = myAnimalRepository.findAll().stream()
+        List<MyAnimalReadResponseDto> animals = myAnimalRepository.findAllOrderByCreatedAtDesc()
+            .stream()
             .map(MyAnimalReadResponseDto::from).toList();
         Integer total = animals.size();
 

--- a/fe/src/components/AnimalCard.jsx
+++ b/fe/src/components/AnimalCard.jsx
@@ -1,9 +1,39 @@
 import React from 'react'
+import logo from '../assets/forpetsLogo.png';
 
-function AnimalCard() {
-	return (
-		<div>AnimalCard</div>
-	)
+function AnimalCard({ animal }) {
+  const {
+    animalName,
+    animalType,
+    arrivalArea,
+    breed,
+    departureArea,
+    id,
+    imageUrl,
+    memo,
+    notice,
+    selectedDate,
+    weight,
+  } = animal;
+
+  return (
+    <li className="w-[290px] h-[400px] bg-white shadow-lg shadow-gray-300 rounded-2xl overflow-hidden relative cursor-pointer">
+      <img
+        src={imageUrl === null ? logo : imageUrl}
+        alt="이동봉사가 필요한 아이 사진"
+        className="w-full h-[45%] object-scale-down"
+      />
+      <section className="flex flex-col gap-3 p-5 mt-2">
+        <p className="flex-1">이름 : {animalName}</p>
+        <p className="flex-1">
+          종류 : {animalType === 'DOG' ? '강아지' : animalType === 'CAT' ? '고양이' : '기타'}
+        </p>
+        <p className="flex-1">봉사날짜 : {selectedDate}</p>
+        <p className="flex-1">출발지역 : {departureArea}</p>
+        <p className="flex-1">도착지역 : {arrivalArea}</p>
+      </section>
+    </li>
+  );
 }
 
 export default AnimalCard

--- a/fe/src/pages/AnimalList.jsx
+++ b/fe/src/pages/AnimalList.jsx
@@ -1,9 +1,36 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react';
+import animalsApi from '../api/animalsApi';
+import RescueAnimalCard from '../components/RescueAnimalCard';
+import AnimalCard from '../components/AnimalCard';
 
 function AnimalList() {
-	return (
-		<div>AnimalList</div>
-	)
+  const [animals, setAnimals] = useState([]);
+
+  const fetchData = async () => {
+    try {
+      const response = await animalsApi.getAnimals();
+      const data = response.data.animals;
+      setAnimals(data);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <>
+      <ul className="flex flex-wrap justify-evenly gap-[18px] mt-10 mb-30">
+        {animals.length > 0 ? (
+          animals.map((animal) => <AnimalCard key={animal.id} animal={animal} />)
+        ) : (
+          <li className="text-2xl mt-50">등록된 이동봉사 요청글이 없습니다</li>
+        )}
+      </ul>
+    </>
+  );
 }
 
-export default AnimalList
+export default AnimalList;


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-97

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 나의 아이 더보기 리스트 화면 구현
  - 더보기 리스트의 항목을 피그마와 다르게 5개로 줄임  
- 나의 아이 데이터 봉사일 내림차순으로 불러오도록 수정
- workflow create .env file run 수정

## 📸 스크린샷
<img width="1507" alt="Screenshot 2025-03-29 at 14 51 30" src="https://github.com/user-attachments/assets/83ec659f-6c07-49fb-bcd3-c9f6bd3f76c8" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

- 더보기 리스트의 항목을 피그마와 다르게 5개로 줄임. 논의 필요.