### PR TITLE
FR-98 [BE] 채팅방 퇴장/삭제 API 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/entity/ChatMessage.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/entity/ChatMessage.java
@@ -40,6 +40,11 @@ public class ChatMessage extends BaseTimeEntity {
         this.content = content;
     }
 
+    // ChatRoom을 설정하는 연관관계 편의 메서드
+    public void setChatRoom(ChatRoom chatRoom) {
+        this.chatRoom = chatRoom;
+    }
+
     public void updateContent(String content) {
         this.content = content;
     }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatmessage/service/ChatMessageService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatmessage/service/ChatMessageService.java
@@ -28,6 +28,8 @@ public class ChatMessageService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
             .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
 
+        log.info("Sender ID- test1: {}", requestDto.getSenderId());
+
         User user = userRepository.findById(requestDto.getSenderId())
             .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
@@ -37,6 +39,10 @@ public class ChatMessageService {
         if (!chatRoomRepository.existsUserByRequestorAndVolunteer(chatRoomId, user.getId())) {
             // 채팅방 입장 사용자의 닉네임을 표시하도록 내용 업데이트
             editMessage.updateContent(user.getNickname() + "님이 채팅방에 입장하셨습니다.");
+
+            // 연관관계 설정 (chatRoom에 채팅 메시지 추가)
+            chatRoom.addChatMessage(editMessage);
+
             chatMessageRepository.save(editMessage);
         }
 
@@ -54,6 +60,9 @@ public class ChatMessageService {
 
         ChatMessage chatMessage = requestDto.toEntity(chatRoom);
 
+        // 연관관계 설정 (chatRoom에 채팅 메시지 추가)
+        chatRoom.addChatMessage(chatMessage);
+
         return chatMessageRepository.save(chatMessage);
     }
 
@@ -63,7 +72,7 @@ public class ChatMessageService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
             .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
 
-        log.info("Sender ID: {}", requestDto.getSenderId());
+        log.info("Sender ID- test2: {}", requestDto.getSenderId());
 
         User user = userRepository.findById(requestDto.getSenderId())
             .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
@@ -74,6 +83,10 @@ public class ChatMessageService {
         if (chatRoomRepository.existsUserByRequestorAndVolunteer(chatRoomId, user.getId())) {
             // 채팅방 퇴장 사용자의 닉네임을 표시하도록 내용 업데이트
             editMessage.updateContent(user.getNickname() + "님이 채팅방에서 퇴장하셨습니다.");
+
+            // 연관관계 설정 (chatRoom에 채팅 메시지 추가)
+            chatRoom.addChatMessage(editMessage);
+
             chatMessageRepository.save(editMessage);
         }
 

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/controller/ChatRoomController.java
@@ -11,9 +11,9 @@ import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,9 +34,8 @@ public class ChatRoomController {
     @PostMapping
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(
         @RequestBody @Valid ChatRoomRequestDto requestDto, @AuthenticationPrincipal User user) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(
-            ApiResponse.ok("채팅방이 생성되었습니다.", "CREATED",
-                chatRoomService.createChatRoom(requestDto, user)));
+        return ResponseEntity.ok(ApiResponse.ok("채팅방이 생성되었습니다.", "CREATED",
+            chatRoomService.createChatRoom(requestDto, user)));
     }
 
     // 내가 요청자로 속한 채팅방 전체 조회
@@ -55,7 +54,7 @@ public class ChatRoomController {
             chatRoomService.getVolunteerChatRooms(volunteerId)));
     }
 
-    // 채팅방 개별 조회
+    // 채팅방 상세 조회
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ApiResponse<ChatRoomDetailResponseDto>> getChatRoom(
         @PathVariable Long chatRoomId) {
@@ -69,7 +68,17 @@ public class ChatRoomController {
         @PathVariable Long chatRoomId,
         @RequestBody @Valid ChatRoomUpdateRequestRecord requestRecord,
         @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(ApiResponse.ok(chatRoomId + "번 채팅방이 수정되었습니다.", "OK",
+        return ResponseEntity.ok(ApiResponse.ok(chatRoomId + "번 채팅방이 수정되었습니다.", "UPDATED",
             chatRoomService.updateChatRoom(chatRoomId, requestRecord, user)));
+    }
+
+    // 채팅방 삭제
+    @DeleteMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChatRoom(@PathVariable Long chatRoomId,
+        @AuthenticationPrincipal User user) {
+        chatRoomService.deleteChatRoom(chatRoomId, user);
+
+        return ResponseEntity.ok(
+            ApiResponse.ok(chatRoomId + "번 채팅방에서 퇴장했습니다.", "DELETED", null));
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/entity/ChatRoom.java
@@ -1,9 +1,11 @@
 package com.forpets.be.domain.chat.chatroom.entity;
 
 import com.forpets.be.domain.animal.entity.MyAnimal;
+import com.forpets.be.domain.chat.chatmessage.entity.ChatMessage;
 import com.forpets.be.domain.servicevolunteer.entity.ServiceVolunteer;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +16,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,9 +49,18 @@ public class ChatRoom extends BaseTimeEntity {
     @JoinColumn(name = "volunteer_user_id", nullable = false)
     private User volunteer;
 
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RoomState state;
+
+    @Column(nullable = false)
+    private Boolean isRequestorLeft;
+
+    @Column(nullable = false)
+    private Boolean isVolunteerLeft;
 
     @Builder
     public ChatRoom(MyAnimal myAnimal, ServiceVolunteer serviceVolunteer, User requestor,
@@ -56,6 +70,14 @@ public class ChatRoom extends BaseTimeEntity {
         this.requestor = requestor;
         this.volunteer = volunteer;
         this.state = RoomState.getDefault();
+        this.isRequestorLeft = false;
+        this.isVolunteerLeft = false;
+    }
+
+    // 채팅 메시지를 추가하는 연관관계 편의 메서드
+    public void addChatMessage(ChatMessage chatMessage) {
+        chatMessages.add(chatMessage);
+        chatMessage.setChatRoom(this);
     }
 
     // 채팅방 상태 업데이트
@@ -63,5 +85,15 @@ public class ChatRoom extends BaseTimeEntity {
         this.state = state;
 
         return this;
+    }
+
+    // 요청자가 채팅방에서 나갔는지 설정
+    public void setIsRequestorLeft(boolean isLeft) {
+        this.isRequestorLeft = isLeft;
+    }
+
+    // 봉사자가 채팅방에 나갔는지 설정
+    public void setIsVolunteerLeft(boolean isLeft) {
+        this.isVolunteerLeft = isLeft;
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/repository/ChatRoomRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    // 나의 아이 등록글과 봉사 등록글 id를 확인하고 특정 게시글에서 시작된 채팅방이 이미 존재하는지 조회
+    // 나의 아이 등록글과 봉사 등록글 id를 확인하고 특정 게시글에서 시작된 채팅방이 이미 존재하는지 확인
     @Query("SELECT CASE WHEN COUNT(c) > 0 THEN TRUE ELSE FALSE END "
         + "FROM ChatRoom c "
         + "WHERE c.requestor = :requestor AND c.volunteer = :volunteer "

--- a/be/src/main/java/com/forpets/be/global/websocket/config/WebSocketConfig.java
+++ b/be/src/main/java/com/forpets/be/global/websocket/config/WebSocketConfig.java
@@ -29,7 +29,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             // 웹소켓 연결 엔드포인트 설정
             .addEndpoint("/ws/connection")
             // 웹소켓 서버에 요청 시 포페츠 도메인과 로컬 접속 요청을 허용하도록 설정 (CORS)
-            .setAllowedOrigins("http://localhost:5173", allowedOrigin);
+            .setAllowedOrigins("http://localhost:5173", allowedOrigin)
+            // 소켓을 지원하지 않는 브라우저일 경우 sock JS를 사용하도록 설정
+            .withSockJS();
     }
 
     // STOMP 메시지 브로커 설정


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-98

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 채팅방에서 참여자가 모두 나갔을 경우 삭제되도록 로직 구현
  - 채팅방을 나가는 참여자가 이동봉사 요청자인경우, 요청자 퇴장 처리
  - 채팅방을 나가는 참여자가 봉사자인 경우, 봉사자 퇴장 처리
- 채팅방 삭제 시 채팅 메시지도 삭제되도록 hard delete 로직 구현
  - CascadeType.REMOVE, OrphanRemoval = true
- 채팅방-채팅 메시지 간 @OneToMany 관계 및 연관관계 편의 메서드 구현

- 응답 상태 코드에 대한 메시지 팀 컨벤션에 맞춰 수정
  - 생성 : CREATED
  - 조회 : OK
  - 수정 : UPDATED
  - 삭제 : DELETED

- withSockJS()을 코드를 통해 소켓을 지원하지 않는 브라우저일 경우 sock JS를 사용하도록 설정

## 📸 스크린샷
<img width="1023" alt="스크린샷 2025-03-29 오후 11 01 26" src="https://github.com/user-attachments/assets/33b55900-1d45-4687-b5b2-b871cb0c7198" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항