### PR TITLE
FR-120 [BE] 이동봉사 현황 삭제 API 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
@@ -10,7 +10,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,5 +49,14 @@ public class VolunteerWorkStatusController {
         @AuthenticationPrincipal User user) {
         return ResponseEntity.ok(ApiResponse.ok(user.getNickname() + "님의 이동봉사 현황이 조회되었습니다.", "OK",
             volunteerWorkStatusService.getMyVolunteerWorkStatus(user)));
+    }
+
+    // 이동봉사 현황 삭제
+    @DeleteMapping("/volunteer-work-status/{volunteerWorkStatusId}")
+    public ResponseEntity<ApiResponse<Void>> deleteVolunteerWorkStatus(
+        @PathVariable Long volunteerWorkStatusId) {
+        volunteerWorkStatusService.deleteVolunteerWorkStatus(volunteerWorkStatusId);
+
+        return ResponseEntity.ok(ApiResponse.ok("이동봉사 현황이 삭제되었습니다.", "DELETED", null));
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/service/VolunteerWorkStatusService.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/service/VolunteerWorkStatusService.java
@@ -111,4 +111,14 @@ public class VolunteerWorkStatusService {
 
         return VolunteerWorkStatusListResponseDto.from(volunteerWorkStatusResponseDtos, total);
     }
+
+    // 이동봉사 현황 삭제
+    @Transactional
+    public void deleteVolunteerWorkStatus(Long volunteerWorkStatusId) {
+        VolunteerWorkStatus volunteerWorkStatus = volunteerWorkStatusRepository.findById(
+                volunteerWorkStatusId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 이동봉사 현황을 찾을 수 없습니다."));
+        
+        volunteerWorkStatusRepository.delete(volunteerWorkStatus);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-120

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 이동봉사 현황 id를 Path parameter로 받아서 해당하는 이동봉사 현황글을 삭제
  - 약속 취소 → 이동봉사 현황이 delete

## 📸 스크린샷
<img width="1023" alt="스크린샷 2025-03-31 오후 9 01 07" src="https://github.com/user-attachments/assets/25688aa4-a650-46e8-8b2d-9ec9144e3829" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항