### PR TITLE
FR-121 [BE] 이동봉사 현황 수정 API 구현

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
@@ -27,12 +27,13 @@ public class VolunteerWorkStatusController {
 
     private final VolunteerWorkStatusService volunteerWorkStatusService;
 
-    // 이동봉사 현황 생성
+    // 이동봉사 현황 생성 (약속 잡기)
     @PostMapping("/volunteer-work-status")
     public ResponseEntity<ApiResponse<VolunteerWorkStatusResponseDto>> createServiceStatus(
-        @RequestBody @Valid VolunteerWorkStatusRequestDto requestDto) {
+        @RequestBody @Valid VolunteerWorkStatusRequestDto requestDto,
+        @AuthenticationPrincipal User user) {
         return ResponseEntity.ok(ApiResponse.ok("이동봉사 현황이 생성되었습니다.", "CREATED",
-            volunteerWorkStatusService.createServiceStatus(requestDto)));
+            volunteerWorkStatusService.createServiceStatus(requestDto, user)));
     }
 
     // 이동봉사 현황 전체 조회

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +50,15 @@ public class VolunteerWorkStatusController {
         @AuthenticationPrincipal User user) {
         return ResponseEntity.ok(ApiResponse.ok(user.getNickname() + "님의 이동봉사 현황이 조회되었습니다.", "OK",
             volunteerWorkStatusService.getMyVolunteerWorkStatus(user)));
+    }
+
+    // 이동봉사 현황 수정
+    @PatchMapping("/volunteer-work-status/{volunteerWorkStatusId}")
+    public ResponseEntity<ApiResponse<VolunteerWorkStatusResponseDto>> updateVolunteerWorkStatus(
+        @PathVariable Long volunteerWorkStatusId,
+        @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(ApiResponse.ok("이동봉사 현황이 수정되었습니다.", "UPDATED",
+            volunteerWorkStatusService.updateVolunteerWorkStatus(volunteerWorkStatusId, user)));
     }
 
     // 이동봉사 현황 삭제

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/controller/VolunteerWorkStatusController.java
@@ -52,7 +52,7 @@ public class VolunteerWorkStatusController {
             volunteerWorkStatusService.getMyVolunteerWorkStatus(user)));
     }
 
-    // 이동봉사 현황 수정
+    // 이동봉사 현황 수정 (이동 완료)
     @PatchMapping("/volunteer-work-status/{volunteerWorkStatusId}")
     public ResponseEntity<ApiResponse<VolunteerWorkStatusResponseDto>> updateVolunteerWorkStatus(
         @PathVariable Long volunteerWorkStatusId,
@@ -61,11 +61,11 @@ public class VolunteerWorkStatusController {
             volunteerWorkStatusService.updateVolunteerWorkStatus(volunteerWorkStatusId, user)));
     }
 
-    // 이동봉사 현황 삭제
+    // 이동봉사 현황 삭제 (약속 취소)
     @DeleteMapping("/volunteer-work-status/{volunteerWorkStatusId}")
     public ResponseEntity<ApiResponse<Void>> deleteVolunteerWorkStatus(
-        @PathVariable Long volunteerWorkStatusId) {
-        volunteerWorkStatusService.deleteVolunteerWorkStatus(volunteerWorkStatusId);
+        @PathVariable Long volunteerWorkStatusId, @AuthenticationPrincipal User user) {
+        volunteerWorkStatusService.deleteVolunteerWorkStatus(volunteerWorkStatusId, user);
 
         return ResponseEntity.ok(ApiResponse.ok("이동봉사 현황이 삭제되었습니다.", "DELETED", null));
     }

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/response/VolunteerWorkStatusResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/response/VolunteerWorkStatusResponseDto.java
@@ -19,7 +19,7 @@ public class VolunteerWorkStatusResponseDto {
     private final String volunteerNickname;
     private final String departureArea;
     private final String arrivalArea;
-    private final VolunteerStatus state;
+    private final VolunteerStatus status;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
@@ -33,7 +33,7 @@ public class VolunteerWorkStatusResponseDto {
             .volunteerNickname(volunteer.getNickname())
             .departureArea(myAnimal.getDepartureArea())
             .arrivalArea(myAnimal.getArrivalArea())
-            .state(volunteerWorkStatus.getState())
+            .status(volunteerWorkStatus.getStatus())
             .createdAt(volunteerWorkStatus.getCreatedAt())
             .updatedAt(volunteerWorkStatus.getUpdatedAt())
             .build();

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/entity/VolunteerWorkStatus.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/entity/VolunteerWorkStatus.java
@@ -42,13 +42,20 @@ public class VolunteerWorkStatus extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private VolunteerStatus state;
+    private VolunteerStatus status;
 
     @Builder
     public VolunteerWorkStatus(MyAnimal myAnimal, User requestor, User volunteer) {
         this.myAnimal = myAnimal;
         this.requestor = requestor;
         this.volunteer = volunteer;
-        this.state = VolunteerStatus.IN_PROGRESS;
+        this.status = VolunteerStatus.IN_PROGRESS;
+    }
+
+    // 이동봉사 현황 상태 업데이트
+    public VolunteerWorkStatus updateStatus(VolunteerStatus status) {
+        this.status = status;
+
+        return this;
     }
 }

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/repository/VolunteerWorkStatusRepository.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/repository/VolunteerWorkStatusRepository.java
@@ -16,7 +16,7 @@ public interface VolunteerWorkStatusRepository extends JpaRepository<VolunteerWo
         User volunteer);
 
     // 상태에 대한 이동봉사 현황 조회
-    List<VolunteerWorkStatus> findAllByState(VolunteerStatus state);
+    List<VolunteerWorkStatus> findAllByStatus(VolunteerStatus status);
 
     // 로그인한 사용자가 요청자 또는 봉사자로 참여했던 이동봉사 현황 조회
     @Query("SELECT v FROM VolunteerWorkStatus v "

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/service/VolunteerWorkStatusService.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/service/VolunteerWorkStatusService.java
@@ -112,7 +112,7 @@ public class VolunteerWorkStatusService {
         return VolunteerWorkStatusListResponseDto.from(volunteerWorkStatusResponseDtos, total);
     }
 
-    // 이동봉사 현황 수정
+    // 이동봉사 현황 수정 (이동 완료)
     @Transactional
     public VolunteerWorkStatusResponseDto updateVolunteerWorkStatus(Long volunteerWorkStatusId,
         User user) {
@@ -120,7 +120,7 @@ public class VolunteerWorkStatusService {
                 volunteerWorkStatusId)
             .orElseThrow(() -> new IllegalArgumentException("해당 이동봉사 현황을 찾을 수 없습니다."));
 
-        // 이동 완료 버튼은 이동봉사 요청자만 상태 변경 가능하도록 검증
+        // 이동 완료 버튼은 이동봉사 요청자만 상태 수정 가능하도록 검증
         if (!user.getId().equals(volunteerWorkStatus.getRequestor().getId())) {
             throw new IllegalArgumentException("요청자만 이동 완료 처리를 할 수 있습니다.");
         }
@@ -137,12 +137,18 @@ public class VolunteerWorkStatusService {
             volunteerWorkStatus.getVolunteer());
     }
 
-    // 이동봉사 현황 삭제
+    // 이동봉사 현황 삭제 (약속 취소)
     @Transactional
-    public void deleteVolunteerWorkStatus(Long volunteerWorkStatusId) {
+    public void deleteVolunteerWorkStatus(Long volunteerWorkStatusId, User user) {
         VolunteerWorkStatus volunteerWorkStatus = volunteerWorkStatusRepository.findById(
                 volunteerWorkStatusId)
             .orElseThrow(() -> new IllegalArgumentException("해당 이동봉사 현황을 찾을 수 없습니다."));
+
+        // 이동봉사 현황은 요청자와 봉사자만 상태 수정 가능하도록 검증
+        if (!user.getId().equals(volunteerWorkStatus.getRequestor().getId()) && !user.getId()
+            .equals(volunteerWorkStatus.getVolunteer().getId())) {
+            throw new IllegalArgumentException("이동봉사 현황을 삭제할 권한이 없습니다.");
+        }
 
         volunteerWorkStatusRepository.delete(volunteerWorkStatus);
     }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-121

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 이동봉사 현황 수정 API 구현
  - 이동 완료 시 이동봉사 현황 상태를 update해서 IN_PROGRESS → COMPLETED으로 수정
  - 이동봉사 요청자만 이동봉사 현황을 수정할 수 있도록 검증 로작 구현
    - @AuthenticationPrincipal을 통해 로그인한 사용자 id가 요청자 id와 일치하는지 확인
  - 이미 이동봉사 완료 상태(COMPLETED)인 경우에 대한 검증 로직 구현

- 이동봉사 현황 삭제 검증 로직 추가 구현
  - 요청자와 봉사자만 이동봉사 현황을 삭제할 수 있도록 검증 로작 구현
    - @AuthenticationPrincipal을 통해 로그인한 사용자 id가 요청자 또는 봉사자의 id와 일치하지 않은지 확인

- 이동봉사 현황 생성 검증 로직 추가 구현
  - 나의 아이을 등록한 사용자가 요청자인지 검증하는 로직 수정
    - 기존에는 요청자 또는 봉사자인지 확인했다면, 이제는 요청자인지만 검증하도록 수정
  - 요청자와 봉사자만 이동봉사 현황을 삭제할 수 있도록 검증 로작 구현
    - @AuthenticationPrincipal을 통해 로그인한 사용자 id가 요청자 또는 봉사자의 id와 일치하지 않은지 확인

## 📸 스크린샷
- 이동봉사 현황 수정 시 status 값이 COMPLETED로 수정
<img width="1022" alt="스크린샷 2025-04-01 오전 4 58 35" src="https://github.com/user-attachments/assets/40e55a24-5760-4f58-bf0d-d05353ce1059" />

- 이동봉사 현황 수정 후 전체 조회 시에도 status 값이 COMPLETED로 수정된 모습
<img width="1024" alt="스크린샷 2025-04-01 오전 5 00 34" src="https://github.com/user-attachments/assets/6283fb24-91e1-4727-87c9-e0fbeb68f7e5" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항