### PR TITLE
FR-160 [BE] 채팅방 상세 조회 코드 수정

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/dto/response/ChatRoomDetailResponseDto.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 public class ChatRoomDetailResponseDto {
 
     private final Long id;
+    private final Long requestorId;
+    private final Long volunteerId;
     private final String nickname;
     private final String departureArea;
     private final String arrivalArea;

--- a/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
+++ b/be/src/main/java/com/forpets/be/domain/chat/chatroom/service/ChatRoomService.java
@@ -178,6 +178,8 @@ public class ChatRoomService {
 
         return ChatRoomDetailResponseDto.builder()
             .id(chatRoomId)
+            .requestorId(chatRoom.getRequestor().getId())
+            .volunteerId(chatRoom.getVolunteer().getId())
             .nickname(nickname)
             .departureArea(departureArea)
             .arrivalArea(arrivalArea)


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-160

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 채팅방 상세 조회 시 요청자 id, 봉사자 id가 응답 데이터에 포함되도록 수정

## 📸 스크린샷
<img width="1027" alt="스크린샷 2025-04-09 오후 12 26 48" src="https://github.com/user-attachments/assets/635f7bf1-c184-4417-97a3-8fe0186939b1" />

<img width="1029" alt="스크린샷 2025-04-09 오후 12 26 58" src="https://github.com/user-attachments/assets/6a3bb41f-df9b-4d3a-bd50-c12a34b2fa86" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항