### PR TITLE
FR-168 [BE] 이동봉사 현황 코드 수정

### DIFF
--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/request/VolunteerWorkStatusRequestDto.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/request/VolunteerWorkStatusRequestDto.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class VolunteerWorkStatusRequestDto {
 
+    @NotNull(message = "채팅방 id는 필수 입력값입니다.")
+    private Long chatRoomId;
     @NotNull(message = "나의 아이 id는 필수 입력값입니다.")
     private Long myAnimalId;
     @NotNull(message = "요청자 id는 필수 입력값입니다.")

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/response/VolunteerWorkStatusResponseDto.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/dto/response/VolunteerWorkStatusResponseDto.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.volunteerworkstatus.dto.response;
 
 import com.forpets.be.domain.animal.entity.MyAnimal;
+import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.domain.volunteerworkstatus.entity.VolunteerStatus;
 import com.forpets.be.domain.volunteerworkstatus.entity.VolunteerWorkStatus;
@@ -13,6 +14,7 @@ import lombok.Getter;
 public class VolunteerWorkStatusResponseDto {
 
     private final Long id;
+    private final Long chatRoomId;
     private final String imageUrl;
     private final String animalName;
     private final String requestorNickname;
@@ -23,10 +25,11 @@ public class VolunteerWorkStatusResponseDto {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static VolunteerWorkStatusResponseDto from(VolunteerWorkStatus volunteerWorkStatus,
+    public static VolunteerWorkStatusResponseDto from(VolunteerWorkStatus volunteerWorkStatus, ChatRoom chatRoom,
         MyAnimal myAnimal, User requestor, User volunteer) {
         return VolunteerWorkStatusResponseDto.builder()
             .id(volunteerWorkStatus.getId())
+            .chatRoomId(chatRoom.getId())
             .imageUrl(myAnimal.getImageUrl())
             .animalName(myAnimal.getAnimalName())
             .requestorNickname(requestor.getNickname())

--- a/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/entity/VolunteerWorkStatus.java
+++ b/be/src/main/java/com/forpets/be/domain/volunteerworkstatus/entity/VolunteerWorkStatus.java
@@ -1,6 +1,7 @@
 package com.forpets.be.domain.volunteerworkstatus.entity;
 
 import com.forpets.be.domain.animal.entity.MyAnimal;
+import com.forpets.be.domain.chat.chatroom.entity.ChatRoom;
 import com.forpets.be.domain.user.entity.User;
 import com.forpets.be.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -40,15 +41,20 @@ public class VolunteerWorkStatus extends BaseTimeEntity {
     @JoinColumn(name = "volunteer_user_id", nullable = false)
     private User volunteer;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private VolunteerStatus status;
 
     @Builder
-    public VolunteerWorkStatus(MyAnimal myAnimal, User requestor, User volunteer) {
+    public VolunteerWorkStatus(MyAnimal myAnimal, User requestor, User volunteer, ChatRoom chatRoom) {
         this.myAnimal = myAnimal;
         this.requestor = requestor;
         this.volunteer = volunteer;
+        this.chatRoom = chatRoom;
         this.status = VolunteerStatus.IN_PROGRESS;
     }
 


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-168

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 이동봉사 현황 테이블에 채팅방 id를 FK로 받도록 수정
  - 이동봉사 현황 엔티티(VolunteerWorkStatus)에서 @OneToOne 관계로 채팅방과 연결

- 이동봉사 현황 생성 시 채팅방 id를 요청 데이터로 받도록 수정

- 이동봉사 현황 전체 조회, 내 이동봉사 현황 조회, 이동봉사 현황 수정 시 채팅방 id가 응답 데이터에 포함되도록 수정

## 📸 스크린샷
- 이동봉사 현황 생성 시 채팅방 id(chatRoomId)를 요청
<img width="1036" alt="스크린샷 2025-04-10 오후 2 34 20" src="https://github.com/user-attachments/assets/fc3dc48a-9167-41b0-a658-f7b54a3adecb" />

- 이동봉사 현황 전체 조회 시 채팅방 id(chatRoomId)를 응답
  - 내 이동봉사 현황 조회, 이동봉사 현황 수정 시에도 채팅방 id를 응답
<img width="1039" alt="스크린샷 2025-04-10 오후 2 37 50" src="https://github.com/user-attachments/assets/d78e7e95-49c5-4741-99a3-15c0cb62b7c4" />


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항