### PR TITLE
FR-176 [FE] 메인, 이동봉사 현황 코드 수정

### DIFF
--- a/fe/index.html
+++ b/fe/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
+    <link rel="apple-touch-icon" type="image/png" href="/assets/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- <script
       type="text/javascript"
@@ -16,7 +17,7 @@
       type="text/javascript"
       src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
     ></script>
-    <title>Vite + React</title>
+    <title>포페츠 - 유기동물을 위한 이동봉사 서비스</title>
   </head>
   <body>
     <div id="root"></div>

--- a/fe/src/components/VolunteerWorkStatusCard.jsx
+++ b/fe/src/components/VolunteerWorkStatusCard.jsx
@@ -2,9 +2,10 @@ import { Navigate } from 'react-router-dom';
 
 function VolunteerWorkStatusCard({ service }) {
   const stateMap = {
-    progress: '진행중',
-    done: '완료',
+    IN_PROGRESS: '진행중',
+    COMPLETED: '완료',
   };
+
   // const navigate = useNavigate();
 
   // const handleRescueAnimalDetail = () => {
@@ -12,14 +13,14 @@ function VolunteerWorkStatusCard({ service }) {
   // };
   return (
     <li
-      className="justify-around gap-2 min-w-[400px] w-[48%] h-[180px] flex bg-white shadow-md border border-gray-300 rounded-sm overflow-hidden relative cursor-pointer p-1"
+      className="justify-around gap-2 min-w-[400px] w-[48%] h-[210px] flex bg-white shadow-md border border-gray-300 rounded-sm overflow-hidden relative cursor-pointer p-1"
       // onClick={handleRescueAnimalDetail}
     >
       <img
         // src=""
         src={`${service.imageUrl}`}
         alt="동물 사진"
-        className="w-[180px] h-[170px] object-cover border-1 border-amber-500 rounded-sm "
+        className="w-[180px] h-[200px] object-cover border-1 border-amber-500 rounded-sm "
       />
       <div className="w-[250px] p-1 flex flex-col gap-1">
         <div className="flex gap-1">
@@ -43,7 +44,7 @@ function VolunteerWorkStatusCard({ service }) {
         </div>
         <div className="flex gap-1">
           <p className="w-[50px] text-gray-500">상태</p>
-          <p>{stateMap[service.state] || '알 수 없음'}</p>
+          <p>{stateMap[service.status] || '알 수 없음'}</p>
         </div>
         {/* </div> */}
       </div>


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- FR-176

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 메인 페이지 타이틀 수정
    - 지금은 ‘Vite + React’ 라고 나오는 것을 ‘포페츠- 유기동물 이동봉사 매칭 플랫폼’ 으로 수정
    
- 메인 페이지 타이틀 로고 추가

- 이동봉사 현황에서 상태 부분이 ‘알 수 없음’으로 표시되던 것을 각 케이스에 맞게 표시되도록 수정
- 이동봉사 현황에서 여정의 높이 사이즈로 인해 상태 부분이 잘려서 나오던 거 표시되도록 수정

## 📸 스크린샷
- 메인 페이지 수정
![스크린샷 2025-04-22 오후 5 14 35](https://github.com/user-attachments/assets/e2e63559-cd90-4a9b-a563-afdd80f261f2)

- 이동봉사 현황 페이지 수정
![스크린샷 2025-04-22 오후 5 14 54](https://github.com/user-attachments/assets/7e2fb088-315b-4a6e-bbeb-de2a7fd89dd6)


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항